### PR TITLE
Ensure a value is asigned to Quantity field

### DIFF
--- a/facturae/facturae.py
+++ b/facturae/facturae.py
@@ -715,7 +715,7 @@ class InvoiceLine(XmlModel):
         self.sequencenumber = XmlField('SequenceNumber')
         self.deliverynotesreference = DeliveryNotesReference()
         self.itemdescription = XmlField('ItemDescription')
-        self.quantity = XmlField('Quantity')
+        self.quantity = XmlField('Quantity', rep=lambda x: '%.8f' % x)
         self.unitofmeasure = XmlField('UnitOfMeasure')
         self.unitpricewithouttax = XmlField('UnitPriceWithoutTax',
                                             rep=lambda x: '%.8f' % x)


### PR DESCRIPTION
Together with @gdalmau we found a bug when an invoice line had a **Quantity** value of 0. The line wasn't included to the XML. The **Quantity** field is required so we needed to input it as a 0 on the XML.